### PR TITLE
WIP: Adding Markdown format

### DIFF
--- a/files/canting-tribe-nda-1.0.1.md
+++ b/files/canting-tribe-nda-1.0.1.md
@@ -1,0 +1,262 @@
+# The Canting Tribe NDA
+_Version 1.0.1_
+
+The parties agree:
+
+## 1. Mutual Nondisclosure.
+
+"Disclosing Party" describes each party with respect to
+Confidential Information it discloses to the other party. "Receiving Party" describes each
+party with respect to Confidential Information it receives from the other party.
+
+## Purpose
+
+The parties anticipate disclosure of Confidential Information for the purpose on
+the attached certificate (the "Purpose").
+
+## Confidential Information.
+
+* (a) Categories of Confidential Information. Subject to Section 3(b) (Exclusions
+from Confidential Information), "Confidential Information" means the
+following kinds of information:
+  * (i) information disclosed by Disclosing Party during the term of this
+agreement that is related to the business of Disclosing Party;
+  * (ii) the fact that the parties are pursuing the Purpose;
+  * (iii) the terms of this agreement;
+  * (iv) the fact that the parties have entered into this agreement; and
+  * (v) other information derived from these kinds of information.
+* (b) Exclusions from Confidential Information.
+  * (i) Public Information. Information that is now public is not Confidential
+Information. Confidential Information that becomes public, other than as a
+result of breach of this agreement, ceases to be Confidential Information.
+  * (ii) Otherwise Acquired Information. Information that Receiving Party
+receives other than from Disclosing Party is not Confidential Information,
+unless the disclosure breached a confidentiality obligation to Disclosing
+Party that Disclosing Party made known to Receiving Party.
+  * (iii) Independently Developed Information. Information Receiving Party
+develops independently is not, or ceases to be, Confidential Information of
+Disclosing Party. Receiving Party shall bear the burden of proving
+independent development using contemporaneous documentary evidence.
+
+## 4. Confidentiality Obligations.
+* (a) Nondisclosure. Except as described in Section 4(b) (Permitted Disclosure),
+Receiving Party shall not disclose Confidential Information to anyone.
+* (b) Permitted Disclosure. Receiving Party may disclose Confidential Information to
+the following personnel:
+  * (i) if Receiving Party is a legal entity, employees, independent contractors,
+officers, directors, and agents of Receiving Party ("Personnel") who:
+    * (A) have a need to know the Confidential Information to advance the
+Purpose; and
+    * (B) have entered written confidentiality agreements with Receiving
+Party that impose confidentiality obligations, affording as much or
+more protection as those of this agreement, that apply to the
+Confidential Information; and
+  * (ii) legal and financial advisers providing services to Receiving Party under
+confidentiality obligations imposed either by law or by professional rules
+("Advisers").
+* (c) Limited Use. Receiving Party shall use Confidential Information only to advance
+the Purpose.
+* (d) Security Measures. Receiving Party shall take measures to secure materials
+embodying Confidential Information at least as protective as those Receiving
+Party employs to secure its own Confidential Information, but in any event no less
+than reasonable measures.
+* (e) Preserve Proprietary Notices. Receiving Party shall not remove any proprietary
+notices attached to materials embodying Confidential Information.
+* (f) No Illegal Dealing in Securities. Receiving Party shall not break securities laws
+by purchasing, selling, or otherwise dealing in securities of Disclosing Party on
+the basis of Confidential Information that is material, nonpublic information.
+Receiving Party shall instruct anyone to whom it discloses Confidential
+Information that may be material, nonpublic information not to break securities
+laws by dealing in securities of Disclosing Party.
+* (g) No Reverse Engineering. Receiving Party shall not reverse engineer any material
+embodying Confidential Information.
+* (h) Mitigate Legally Required Disclosure. The following obligations apply when
+the law requires disclosure of Confidential Information and when Receiving Party
+reasonably expects that the law may require disclosure of Confidential
+Information:
+  * (i) Give Notice of Required Disclosure. If legally permitted, Receiving
+Party shall promptly notify Disclosing Party of the nature of the
+requirement and the Confidential Information affected. If practical,
+Receiving Party shall give notice quickly enough to afford Disclosing
+Party practical chance to start a proceeding to protect the confidentiality of
+the Confidential Information. On Disclosing Party request, Receiving
+Party shall cooperate with Disclosing Party in any such proceeding by
+providing reasonable assistance.
+  * (ii) Reimburse Expenses of Cooperation. Disclosing Party shall reimburse
+Receiving Party's reasonable out-of-pocket expenses of cooperating in any
+proceeding described in Section 4(h)(i) (Give Notice of Required
+Disclosure).
+* (i) Give Notice of Leaks. Receiving Party shall give Disclosing Party notice when
+Receiving Party becomes aware, suspects, or anticipates that Confidential
+Information has been or will be disclosed or used in breach of this agreement or
+other confidentiality agreements with Disclosing Party.
+* (j) Return and Destruction.
+  * (i) Subject to Section 4(k) (Records Policy), when this agreement terminates,
+Receiving Party shall promptly:
+    * (A) return all materials embodying Confidential Information that
+Disclosing Party provided with request to return; and
+    * (B) destroy all parts of other materials that embody Confidential
+Information.
+* (k) Records Policy. When this agreement terminates, if Receiving Party has a written
+records retention policy for the creation and scheduled destruction of archival or
+backup records, and only specialized personnel can routinely access those records,
+then Receiving Party may retain materials embodying Confidential Information
+until destroyed under that policy.
+* (l) Comply with Export Controls. Both parties shall comply with export and
+reexport laws with respect to Confidential Information.
+* (m) Compliance and Oversight.
+  * (i) Receiving Party shall ensure that its Advisers abide by the confidentiality
+obligations of Receiving Party under this agreement. If Receiving Party is
+a legal entity, Receiving Party shall also ensure that its Personnel abide by
+the confidentiality obligations of Receiving Party under this agreement.
+Breach of Receiving Party obligations by Receiving Party Personnel or
+Receiving Party Advisers will be deemed breach of this agreement by
+Receiving Party itself.
+  * (ii) If Receiving Party is a legal entity, Receiving Party shall provide
+Disclosing Party copies of confidentiality agreements with Personnel who
+receive Confidential Information on Disclosing Party request.
+
+## 5. Clarifications
+
+* (a) No Obligation to Disclose. No terms of this agreement obligate Disclosing Party
+to disclose any Confidential Information.
+* (b) No Obligation to Do Business. No terms of this agreement obligate either party
+to enter any business relationship or agreement, related to the Purpose or
+otherwise.
+* (c) No License. No terms of this agreement grant any license for any patent,
+trademark, copyright, or other intellectual property.
+* (d) No Warranty. Disclosing Party makes no warranty that Confidential Information
+will be complete or accurate.
+* (e) Freedom to Operate. No terms of this agreement prohibit either party from:
+  * (i) competing with the other party;
+  * (ii) entering into any business relationship with any non-party; or
+  * (iii) assigning and reassigning Personnel and Advisers in its sole discretion.
+
+## 6. 18 U.S.C. 1833(b) Notice
+
+* (a) An individual shall not be held criminally or civilly liable under any Federal or
+State trade secret law for the disclosure of a trade secret that:
+  * (i) is made:
+    * (A) in confidence to a Federal, State, or local government official,
+either directly or indirectly, or to an attorney; and
+    * (B) solely for the purpose of reporting or investigating a suspected
+violation of law; or
+  * (ii) is made in a complaint or other document filed in a lawsuit or other
+proceeding, if such filing is made under seal.
+* (b) An individual who files a lawsuit for retaliation by an employer for reporting a
+suspected violation of law may disclose the trade secret to the attorney of the
+individual and use the trade secret information in the court proceeding, if the
+individual:
+  * (i) files any document containing the trade secret under seal; and
+  * (ii) does not disclose the trade secret, except pursuant to court order.
+
+## 7. Equitable Remedies.
+
+Breach of Section 4 (Confidentiality Obligations) would cause
+irreparable harm that money damages could not adequately compensate. Either party will
+be entitled to seek injunctions, restraining orders, and other equitable remedies for
+breaches of Section 4 (Confidentiality Obligations), without posting bond or security, and
+without proving actual damages.
+## 8. Term.
+
+* (a) Expiration. Unless extended by cosigned, written agreement of the parties, this
+agreement will terminate automatically on the first anniversary of the date of this
+agreement.
+* (b) Termination by Notice. Either party may terminate this agreement early by thirty
+calendar days' prior written notice to the other party.
+* (c) Survival. Obligations under Section 4 (Confidentiality Obligations) survive the
+term of this agreement for Confidential Information disclosed during the term for
+five calendar years from the date of termination.
+
+## 9. General Contract Terms.
+* (a) No Assignment or Delegation. Neither party may assign any right or delegate
+any obligation under this agreement without the prior, signed, written consent of
+the other party. Any attempt to assign or delegate without consent will have no
+legal effect.
+* (b) Dispute Resolution. The law of the state on the attached certificate will govern
+all aspects of this agreement. The parties shall bring legal proceedings related to
+this agreement only in state or federal courts located in that state. The parties
+consent to the exclusive jurisdiction of those courts and waive any objection that
+legal proceedings brought there are brought in an inconvenient forum. The parties
+may enforce judgments of those courts in any appropriate forum. A party shall pay
+attorney fees and costs that the other party incurs in any legal proceeding related
+to this agreement that results in final judgments on the merits, in the other party's
+favor, on all the other party's claims.
+* (c) Legal Relationship. The parties to this agreement remain independent
+contractors. This agreement does not create any partnership, joint venture, agency,
+or similar relationship between the parties.
+* (d) Written Amendments and Waivers. The parties will amend this agreement only
+by cosigned, written agreement. The parties will waive parts of this agreement, if
+at all, only by written waiver describing the specific terms waived and in what
+particular instance, signed by the party waiving.
+* (e) Notices. The parties shall send every notice, demand, consent, request, or other
+communication required or allowed by this agreement:
+  * (i) by e-mail to the address the other party provided with their signature; or
+  * (ii) by overnight courier, with signature required for delivery, to the address
+the other party provided with their signature.
+Either party may change its e-mail or postal address for later communications by
+giving notice of a new address.
+* (f) Severability. If a court decides that any part of this agreement is invalid or
+unenforceable for any reason but enforcing the rest of the agreement would serve
+the purpose of protecting Confidential Information to advance the Purpose, then
+rest of this agreement will remain in force.
+* (g) No Third-Party Enforcement. Only the parties may enforce rights under this
+agreement.
+* (h) Entire Agreement. The parties intend the terms of this agreement as the final,
+complete, and only expression of their agreement about protection of Confidential
+Information exchanged to advance the Purpose.
+* (i) Signature. A written or electronically signed copy of this agreement delivered by
+e-mail or other electronic means has the same legal effect as delivering a printed
+and signed original.
+
+[Signature pages follow]
+
+## Signature Pages
+
+I certify that these terms are exactly the same as version 1.0.1 of The Canting Tribe NDA
+published at https://cantingtribe.com.
+
+## Purpose:
+_[State the purpose for sharing confidential information.]_
+
+## State Law:
+_[Name the state whose law will govern the agreement.]_
+
+By:
+Name:
+Date:
+E-Mail:
+
+## Parties
+
+The parties are signing this nondisclosure agreement on the dates by their signatures.
+
+# First Party
+
+Legal Name: _[Write the legal name of the party proposing
+the NDA, like “Super Software, Inc.” or
+“John A. Smith”.]_
+Legal Type: _[Write the company’s jurisdiction and legal
+form, like “Delaware corporation” or “New
+York resident” for an individual.]_
+
+Signature:
+Name:
+Title: _[Leave blank if the party is an individual.]_
+Date:
+E-Mail:
+
+# Second Party
+
+Legal Name: _[Write the legal name of the party receiving
+the NDA, like “Quick Welding LLC” or
+“Jane B. Doe”.]_
+Legal Type: _[Write the company’s jurisdiction and legal
+form, like “Delaware corporation” or “Texas
+resident” for an individual.]_
+
+Signature:
+Name:
+Title: _[Leave blank if the party is an individual.]_
+Date:
+E-Mail:

--- a/index.html
+++ b/index.html
@@ -43,7 +43,8 @@
         <a href=files/canting-tribe-nda-1.0.1.docx>Microsoft Word .docx</a>,
         <a href=files/canting-tribe-nda-1.0.1.pdf>Adobe Acrobat .pdf</a>,
         <a href=files/canting-tribe-nda-1.0.1.odt>OpenDocument .odt</a>,
-        <a href=files/canting-tribe-nda-1.0.1.rtf>Rich Text .rtf</a>
+        <a href=files/canting-tribe-nda-1.0.1.rtf>Rich Text .rtf</a>,
+        <a href=files/catning-tribe-nda-1.0.1.md>Markdown .md</a>,
         and
         <a href=files/canting-tribe-nda-1.0.1-docusign.zip>DocuSign template .zip</a>
         formats, and learn about updates


### PR DESCRIPTION
WIP - TO DO:
- [ ] apply **bold** formatting to defined words
- [ ] feedback: include ```[TOC]``` which is a codimd / hackmd table of contents generator or not?

For ease of table of contents generation / automatic generation of "jump links" to sections, I format the sections as H2s, so have put them all on their own line with the "content" in a new paragraph. This means sections like (1) or (2) look a bit visually different, but sections like (4) which start with an (a) already work like this. It would be convenient for me if you switched the formatting to this method.